### PR TITLE
PRマージ時更新されたsqlファイル一覧をSlackへ通知する

### DIFF
--- a/.github/workflows/sql_template_sync.yml
+++ b/.github/workflows/sql_template_sync.yml
@@ -1,4 +1,4 @@
-name: Google Drive テンプレート同期実行
+name: Google Drive テンプレート同期&通知実行
 on:
   push:
     branches:
@@ -12,6 +12,10 @@ jobs:
     timeout-minutes: 60
     env:
       GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_OAUTH_TOKEN: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      OWNER: nijigen-plot
+      REPOSITORY: sql_management_test
 
     steps:
       - uses: actions/checkout@v3
@@ -22,4 +26,6 @@ jobs:
           python-version: '3.9.11'
       - run: pip install poetry==1.2.0b1
       - run: poetry install
+      - run: apt install -y jq
       - run: poetry run python main.py
+      

--- a/get_pr_diff.sh
+++ b/get_pr_diff.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# 直近のcloseしたPRの番号を取得する
+pulls=$(curl \
+-H "Accept: application/vnd.github+json" \
+-H "Authorization: token ${GITHUB_TOKEN}" \
+"https://api.github.com/repos/${OWNER}/${REPOSITORY}/pulls?state=closed&sort=updated&direction=desc")
+pull_number=$(echo $pulls | jq '.[0].number')
+
+# 直近のcloseしたPR番号から変更差分のあるsqlファイル名を取得する
+file_names=$(curl \
+-H "Accept: application/vnd.github+json" \
+-H "Authorization: token ${GITHUB_TOKEN}" \
+"https://api.github.com/repos/${OWNER}/${REPOSITORY}/pulls/${pull_number}/files" | \
+jq '[.[].filename]' | find -name '*.sql')
+
+echo $file_names

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ SYNC_TARGET_FOLDER = "sql_template"
 
 def main():
     # sql_template内のファイルを同期する
-    # target = search_upload_files.search(SYNC_TARGET_FOLDER)
-    # GDS = googleDriveSync(gd_target_folder_id=GOOGLE_DRIVE_TARGET_ID, upload_target_data=target)
-    # GDS.sync()
+    target = search_upload_files.search(SYNC_TARGET_FOLDER)
+    GDS = googleDriveSync(gd_target_folder_id=GOOGLE_DRIVE_TARGET_ID, upload_target_data=target)
+    GDS.sync()
     # 指定フォルダ内のファイルを消したいだけの場合以下を実行する
     # GDS.file_delete()
     NDFTS = notificationDiffFilesToSlack(channel_id="C03NHHQS62K")

--- a/main.py
+++ b/main.py
@@ -15,7 +15,8 @@ def main():
     # GDS.sync()
     # 指定フォルダ内のファイルを消したいだけの場合以下を実行する
     # GDS.file_delete()
-    notificationDiffFilesToSlack()
+    NDFTS = notificationDiffFilesToSlack(channel_id="C03NHHQS62K")
+    NDFTS.send()
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,17 +1,21 @@
 import search_upload_files
 from google_drive import googleDriveSync
+from notification_to_slack import notificationDiffFilesToSlack
 
 # ファイルを同期するGoogle Drive フォルダ
 GOOGLE_DRIVE_TARGET_ID = "1CpEDoL_vLWibMKar2pFsGAY-F-MSJ9P7"
+# 同期元のフォルダ名
+SYNC_TARGET_FOLDER = "sql_template"
 
 
 def main():
     # sql_template内のファイルを同期する
-    target = search_upload_files.search("sql_template")
-    GDS = googleDriveSync(gd_target_folder_id=GOOGLE_DRIVE_TARGET_ID, upload_target_data=target)
-    GDS.sync()
+    # target = search_upload_files.search(SYNC_TARGET_FOLDER)
+    # GDS = googleDriveSync(gd_target_folder_id=GOOGLE_DRIVE_TARGET_ID, upload_target_data=target)
+    # GDS.sync()
     # 指定フォルダ内のファイルを消したいだけの場合以下を実行する
     # GDS.file_delete()
+    notificationDiffFilesToSlack()
 
 
 if __name__ == "__main__":

--- a/notification_to_slack.py
+++ b/notification_to_slack.py
@@ -9,7 +9,6 @@ class notificationDiffFilesToSlack:
         # 直前のPRで更新されたsqlファイル一覧を取得
         result = subprocess.run("bash get_pr_diff.sh", shell=True, capture_output=True, text=True).stdout
         self.diff_sql_files = result.split(" ")
-        print(self.diff_sql_files)
 
         # Slackの通知の為の認証
         self.slack_client = WebClient(token=os.environ["SLACK_OAUTH_TOKEN"])

--- a/notification_to_slack.py
+++ b/notification_to_slack.py
@@ -1,14 +1,21 @@
+import os
 import subprocess
+
+from slack_sdk import WebClient
 
 
 class notificationDiffFilesToSlack:
-    def __init__(self):
+    def __init__(self, channel_id: str):
         # 直前のPRで更新されたsqlファイル一覧を取得
         result = subprocess.run("bash get_pr_diff.sh", shell=True, capture_output=True, text=True).stdout
         self.diff_sql_files = result.split(" ")
         print(self.diff_sql_files)
 
         # Slackの通知の為の認証
+        self.slack_client = WebClient(token=os.environ["SLACK_OAUTH_TOKEN"])
+        self.slack_channel_id = channel_id
 
     def send(self):
-        
+        nl = "\n"
+        post_text = f"以下のファイルを作成/更新しました。{nl}{nl}{nl.join(self.diff_sql_files)}"
+        self.slack_client.chat_postMessage(channel=self.slack_channel_id, text=post_text)

--- a/notification_to_slack.py
+++ b/notification_to_slack.py
@@ -1,0 +1,14 @@
+import subprocess
+
+
+class notificationDiffFilesToSlack:
+    def __init__(self):
+        # 直前のPRで更新されたsqlファイル一覧を取得
+        result = subprocess.run("bash get_pr_diff.sh", shell=True, capture_output=True, text=True).stdout
+        self.diff_sql_files = result.split(" ")
+        print(self.diff_sql_files)
+
+        # Slackの通知の為の認証
+
+    def send(self):
+        

--- a/poetry.lock
+++ b/poetry.lock
@@ -714,6 +714,18 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "slack-sdk"
+version = "3.17.2"
+description = "The Slack API Platform SDK for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+optional = ["aiodns (>1.0)", "aiohttp (>=3.7.3,<4)", "boto3 (<=2)", "SQLAlchemy (>=1,<2)", "websockets (>=10,<11)", "websocket-client (>=1,<2)"]
+testing = ["pytest (>=6.2.5,<7)", "pytest-asyncio (<1)", "Flask-Sockets (>=0.2,<1)", "Flask (>=1,<2)", "Werkzeug (<2)", "itsdangerous (==1.1.0)", "Jinja2 (==3.0.3)", "pytest-cov (>=2,<3)", "codecov (>=2,<3)", "flake8 (>=4,<5)", "black (==22.3.0)", "click (==8.0.4)", "psutil (>=5,<6)", "databases (>=0.5)", "boto3 (<=2)", "moto (>=3,<4)"]
+
+[[package]]
 name = "stack-data"
 version = "0.3.0"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -796,7 +808,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "8d5ad35b07918d0ff6fc2849db2b5897c35b0c497ea0b7e674dbae2cfd70b13e"
+content-hash = "62cc06209284601a13ae5fc1e2770b7478499032ab4a28154c788370bdba9fbd"
 
 [metadata.files]
 appnope = [
@@ -1008,6 +1020,7 @@ six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+slack-sdk = []
 stack-data = []
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ isort = "^5.10.1"
 google-api-python-client = "^2.52.0"
 google-auth-httplib2 = "^0.1.0"
 google-auth-oauthlib = "^0.5.2"
+slack-sdk = "^3.17.2"
 
 [tool.poetry.dev-dependencies]
 ipykernel = "^6.15.1"

--- a/sql_template/test_20220711.sql
+++ b/sql_template/test_20220711.sql
@@ -1,0 +1,4 @@
+SELECT
+  *
+FROM
+  test_20220711


### PR DESCRIPTION
# 対応内容
- Slackへ直近閉じたプルリクで更新されたsqlファイルの一覧を更新する
  -  閉じたプルリクの更新されたsqlファイル一覧はGithub APIにて取得 
     - https://github.com/nijigen-plot/sql_management_test/blob/0a1eb9f69a0c50420a42b5d619a232fd6cdf77fc/get_pr_diff.sh
  - Slackへの通知はSlack SDK
    - https://github.com/nijigen-plot/sql_management_test/blob/0a1eb9f69a0c50420a42b5d619a232fd6cdf77fc/notification_to_slack.py
  - PRをマージした後にGithub Actionsが走り、通知を行う
    - https://github.com/nijigen-plot/sql_management_test/blob/0a1eb9f69a0c50420a42b5d619a232fd6cdf77fc/.github/workflows/sql_template_sync.yml

